### PR TITLE
feat: add curator cleaning crons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM quay.io/aptible/ubuntu:14.04
 # Install NGiNX.
 RUN apt-get update && \
     apt-get install -y software-properties-common \
-    python-software-properties && \
+    python-software-properties \
+    python-pip && \
     add-apt-repository -y ppa:nginx/stable && apt-get update && \
-    apt-get -y install curl ucspi-tcp apache2-utils nginx ruby
+    apt-get -y install curl ucspi-tcp apache2-utils nginx ruby && \
+    pip install elasticsearch-curator
 
 # We're going to install 2 versions of Kibana, and choose which one to start
 # at runtime based on the Elasticsearch version we see:
@@ -45,11 +47,16 @@ RUN patch -p1 -d "/opt/kibana-${KIBANA_44_VERSION}-linux-x64" < /patches/0001-Se
 # Add script that starts NGiNX in front of Kibana and tails the NGiNX access/error logs.
 ADD bin .
 RUN chmod 700 ./run-kibana.sh
+RUN chmod 700 ./start-cron.sh
 
 # Add tests. Those won't run as part of the build because customers don't need to run
 # them when deploying, but they'll be run in test.sh
 ADD test /tmp/test
 
 EXPOSE 80
+
+ADD . /app
+RUN set -a && . /app/.aptible.env
+RUN ./start-cron.sh
 
 CMD ["./run-kibana.sh"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: ./run-kibana.sh
+cron: ./start-cron.sh

--- a/bin/start-cron.sh
+++ b/bin/start-cron.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+ES_HOST="$($DATABASE_URL | cut -d = -f 2 | cut -d@ -f 2 | cut -d : -f 1)"
+ES_PORT="$($DATABASE_URL | cut -d = -f 2 | cut -d@ -f 2 | cut -d : -f 2)"
+ES_AUTH="$($DATABASE_URL | cut -d = -f 2 | cut -d@ -f 1 | cut -d / -f 3)"
+
+echo >> etc/crontab "20 0 * * * /usr/local/bin/curator --host $ES_HOST --port $ES_PORT --http_auth $ES_AUTH --use_ssl --ssl-no-validate close indices --older-than 90 --time-unit days --timestring '%Y.%m.%d'"
+
+echo >> etc/crontab "25 0 * * * /usr/local/bin/curator --host $ES_HOST --port $ES_PORT --http_auth $ES_AUTH --use_ssl --ssl-no-validate delete indices --older-than 120 --time-unit days --timestring '%Y.%m.%d'"
+
+echo 'crontab created'
+
+exit 0


### PR DESCRIPTION
Run at midnight to close and delete indices older than 90 and 120 days respectively.
